### PR TITLE
DR2-1123 Rename package to match terraform

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,4 +1,4 @@
-package uk.gov.nationalarchives.dr2
+package uk.gov.nationalarchives
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -15,7 +15,7 @@ import uk.gov.nationalarchives.dp.client.Entities.Entity
 import uk.gov.nationalarchives.dp.client.EntityClient
 import uk.gov.nationalarchives.dp.client.fs2.Fs2Client
 import uk.gov.nationalarchives.{DADynamoDBClient, DASNSClient}
-import uk.gov.nationalarchives.dr2.Lambda.{CompactEntity, Config}
+import Lambda.{CompactEntity, Config}
 
 import java.time.OffsetDateTime
 import java.util.{Date, TimeZone}

--- a/src/test/scala/testUtils/ExternalServicesTestUtils.scala
+++ b/src/test/scala/testUtils/ExternalServicesTestUtils.scala
@@ -16,9 +16,8 @@ import uk.gov.nationalarchives.DADynamoDBClient.DynamoDbRequest
 import uk.gov.nationalarchives.dp.client.DataProcessor.EventAction
 import uk.gov.nationalarchives.dp.client.Entities.Entity
 import uk.gov.nationalarchives.dp.client.EntityClient
-import uk.gov.nationalarchives.{DADynamoDBClient, DASNSClient}
-import uk.gov.nationalarchives.dr2.Lambda
-import uk.gov.nationalarchives.dr2.Lambda.CompactEntity
+import uk.gov.nationalarchives.{DADynamoDBClient, DASNSClient, Lambda}
+import Lambda.CompactEntity
 
 import java.time.ZonedDateTime
 import java.util.UUID


### PR DESCRIPTION
All of our current lambdas are under uk.gov.nationalarchives as a package
so I think we'll stick with that for now. This matches what is in the
terraform.
