### PR TITLE
Convert joda DateTime to java.time OffsetDateTime

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.1"
   lazy val mockitoScala = "org.mockito" %% "mockito-scala" % mockitoScalaVersion
   lazy val mockitoScalaTest = "org.mockito" %% "mockito-scala-scalatest" % mockitoScalaVersion
-  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.11"
+  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.12"
   lazy val pureConfigCats = "com.github.pureconfig" %% "pureconfig-cats-effect" % "0.17.4"
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.17.4"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.16"

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -118,7 +118,9 @@ class Lambda extends RequestHandler[ScheduledEvent, Unit] {
 
   private def convertToCompactEntities(entitiesToTransform: List[Entity]): List[CompactEntity] =
     entitiesToTransform.map { entity =>
-      val id = s"${entity.entityType.getOrElse("").toLowerCase()}:${entity.ref}"
+      val id = entity.entityType
+        .map(t => s"${t.toLowerCase()}:${entity.ref}")
+        .getOrElse(entity.ref.toString)
       CompactEntity(id, entity.deleted)
     }
 }

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -118,7 +118,7 @@ class Lambda extends RequestHandler[ScheduledEvent, Unit] {
 
   private def convertToCompactEntities(entitiesToTransform: List[Entity]): List[CompactEntity] =
     entitiesToTransform.map { entity =>
-      val id = s"${entity.entityType.toLowerCase()}:${entity.ref}"
+      val id = s"${entity.entityType.getOrElse("").toLowerCase()}:${entity.ref}"
       CompactEntity(id, entity.deleted)
     }
 }

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -11,14 +11,12 @@ import pureconfig.module.catseffect.syntax._
 import software.amazon.awssdk.services.dynamodb.model._
 import sttp.capabilities.fs2.Fs2Streams
 import uk.gov.nationalarchives.DADynamoDBClient.DynamoDbRequest
+import uk.gov.nationalarchives.Lambda.{CompactEntity, Config}
 import uk.gov.nationalarchives.dp.client.Entities.Entity
 import uk.gov.nationalarchives.dp.client.EntityClient
 import uk.gov.nationalarchives.dp.client.fs2.Fs2Client
-import uk.gov.nationalarchives.{DADynamoDBClient, DASNSClient}
-import Lambda.{CompactEntity, Config}
 
-import java.time.OffsetDateTime
-import java.util.{Date, TimeZone}
+import java.time.{Instant, OffsetDateTime}
 
 class Lambda extends RequestHandler[ScheduledEvent, Unit] {
   private val maxEntitiesPerPage: Int = 1000
@@ -39,9 +37,8 @@ class Lambda extends RequestHandler[ScheduledEvent, Unit] {
     Encoder.forProduct2("id", "deleted")(entity => (entity.id, entity.deleted))
 
   override def handleRequest(event: ScheduledEvent, context: Context): Unit = {
-    val offset = if (TimeZone.getTimeZone("Europe/London").inDaylightTime(new Date())) "+0100" else "+0000"
-    val datetimeOfEventString: String = event.getTime.toString().replace("Z", offset)
-    val eventTriggeredDatetime: OffsetDateTime = OffsetDateTime.parse(datetimeOfEventString)
+    val eventTriggeredDatetime: OffsetDateTime =
+      OffsetDateTime.ofInstant(Instant.ofEpochMilli(event.getTime.getMillis), event.getTime.getZone.toTimeZone.toZoneId)
 
     val entities = for {
       config <- configIo

--- a/src/test/scala/testUtils/ExternalServicesTestUtils.scala
+++ b/src/test/scala/testUtils/ExternalServicesTestUtils.scala
@@ -44,50 +44,50 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
         IO(
           Seq(
             Entity(
-              "CO",
+              Option("CO"),
               UUID.fromString("4148ffe3-fffc-4252-9676-595c22b4fcd2"),
               Some("test file1"),
               deleted = false,
-              "path/1"
+              Option("path/1")
             ),
             Entity(
-              "IO",
+              Option("IO"),
               UUID.fromString("7f094550-7af2-4dc3-a954-9cd7f5c25d7f"),
               Some("test file2"),
               deleted = false,
-              "path/2"
+              Option("path/2")
             ),
             Entity(
-              "SO",
+              Option("SO"),
               UUID.fromString("d7879799-a7de-4aa6-8c7b-afced66a6c50"),
               Some("test file3"),
               deleted = false,
-              "path/3"
+              Option("path/3")
             )
           )
         ),
         IO(
           Seq(
             Entity(
-              "SO",
+              Option("SO"),
               UUID.fromString("b10d021d-c013-48b1-90f9-e4ccc6149602"),
               Some("test file4"),
               deleted = false,
-              "path/4"
+              Option("path/4")
             ),
             Entity(
-              "IO",
+              Option("IO"),
               UUID.fromString("e9f6182f-f1b4-4683-89be-9505f5c943ec"),
               Some("test file5"),
               deleted = false,
-              "path/5"
+              Option("path/5")
             ),
             Entity(
-              "CO",
+              Option("CO"),
               UUID.fromString("97f49c11-3be4-4ffa-980d-e698d4faa52a"),
               Some("test file6"),
               deleted = false,
-              "path/6"
+              Option("path/6")
             )
           )
         )
@@ -197,18 +197,18 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
       entityCaptor.getAllValues.toArray.toList should be(
         List(
           Entity(
-            "SO",
+            Option("SO"),
             UUID.fromString("d7879799-a7de-4aa6-8c7b-afced66a6c50"),
             Some("test file3"),
             deleted = false,
-            "path/3"
+            Option("path/3")
           ),
           Entity(
-            "CO",
+            Option("CO"),
             UUID.fromString("97f49c11-3be4-4ffa-980d-e698d4faa52a"),
             Some("test file6"),
             deleted = false,
-            "path/6"
+            Option("path/6")
           )
         ).take(numOfEntityEventActionsInvocations)
       )


### PR DESCRIPTION
There was an error parsing the date when I ran this in Lambda. Instead
of converting to a string and parsing, you can turn it directly into a
java.time.OffsetDateTime. I tested this running in the lambda and it
seems ok.

I've version bumped the Preservica client. Entity type is now optional so I've changed it to send `type:ref` if the type is there and just `ref` if it isn't.