### PR TITLE
DR2-1177 Add logging to lambda.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-import Dependencies._
+import Dependencies.*
+import uk.gov.nationalarchives.sbt.Log4j2MergePlugin.log4j2MergeStrategy
 ThisBuild / version := "0.1.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "2.13.12"
@@ -16,6 +17,9 @@ lazy val root = (project in file("."))
       awsSnsClient,
       awsSecretsManager,
       catsEffect,
+      log4jSlf4j,
+      log4jCore,
+      log4jTemplateJson,
       pureConfig,
       pureConfigCats,
       sttpClient,
@@ -31,6 +35,6 @@ lazy val root = (project in file("."))
 scalacOptions ++= Seq("-Wunused:imports", "-Werror", "-unchecked", "-deprecation")
 
 (assembly / assemblyMergeStrategy) := {
-  case PathList("META-INF", _*) => MergeStrategy.discard
-  case _                        => MergeStrategy.first
+  case PathList(ps@_*) if ps.last == "Log4j2Plugins.dat" => log4j2MergeStrategy
+  case _ => MergeStrategy.first
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,8 @@ import sbt.*
 
 object Dependencies {
   private val mockitoScalaVersion = "1.17.22"
-  private val awsLibraryVersion = "1.12.553"
+  private val awsLibraryVersion = "1.12.555"
+  lazy val logbackVersion = "2.20.0"
 
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.141"
   lazy val awsDynamoDbClient = "uk.gov.nationalarchives" %% "da-dynamodb-client" % "0.1.22"
@@ -12,6 +13,9 @@ object Dependencies {
   lazy val awsSnsClient = "uk.gov.nationalarchives" %% "da-sns-client" % "0.1.22"
   lazy val awsSecretsManager = "com.amazonaws" % "aws-java-sdk-secretsmanager" % awsLibraryVersion
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.1"
+  lazy val log4jSlf4j = "org.apache.logging.log4j" % "log4j-slf4j-impl" % logbackVersion
+  lazy val log4jCore = "org.apache.logging.log4j" % "log4j-core" % logbackVersion
+  lazy val log4jTemplateJson = "org.apache.logging.log4j" % "log4j-layout-template-json" % logbackVersion
   lazy val mockitoScala = "org.mockito" %% "mockito-scala" % mockitoScalaVersion
   lazy val mockitoScalaTest = "org.mockito" %% "mockito-scala-scalatest" % mockitoScalaVersion
   lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.18"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.eed3si9n" %% "sbt-assembly" % "2.1.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("uk.gov.nationalarchives" % "sbt-assembly-log4j2" % "0.0.2")

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,11 @@
+status = warn
+
+name = DR2LambdaLogConfiguration
+
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.json.type = JsonTemplateLayout
+
+rootLogger.level = info
+
+rootLogger.appenderRef.stdout.ref = consoleLogger


### PR DESCRIPTION
I've added:
* Log4j libraries including the json template and slf4j implementation.
* The merge strategy which allows the jar to be built properly.
* The log4j config
* The lines actually doing the logging.

This also allows the logging in the Preservica client to work so we get
a log line each time we make an http request to Preservica.
